### PR TITLE
fix: upgrading Python version to 3.13 for the lambda layers

### DIFF
--- a/blueprints/multipage-document-analysis/backend/pace_backend/__init__.py
+++ b/blueprints/multipage-document-analysis/backend/pace_backend/__init__.py
@@ -223,7 +223,7 @@ class PACEBackendStack(Stack):
             self,
             "StatusEnumLayer",
             entry=os.path.join(os.path.dirname(__file__), "shared"),
-            compatible_runtimes=[lambda_.Runtime.PYTHON_3_12],
+            compatible_runtimes=[lambda_.Runtime.PYTHON_3_13],
         )
 
         # Create API from construct

--- a/blueprints/multipage-document-analysis/backend/pace_backend/api/__init__.py
+++ b/blueprints/multipage-document-analysis/backend/pace_backend/api/__init__.py
@@ -116,7 +116,7 @@ class DocumentAPI(Construct):
             entry="./pace_backend/api/lambda/start_text_extraction_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[shared_status_lambda_layer],
             environment={
                 "DOCUMENTS_DYNAMO_DB_TABLE_NAME": documents_table.table_name,
@@ -160,7 +160,7 @@ class DocumentAPI(Construct):
             entry="./pace_backend/api/lambda/get_job_status_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "DOCUMENTS_DYNAMO_DB_TABLE_NAME": documents_table.table_name,
             },
@@ -190,7 +190,7 @@ class DocumentAPI(Construct):
             entry="./pace_backend/api/lambda/get_job_details_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[shared_status_lambda_layer],
             environment={
                 "DOCUMENTS_DYNAMO_DB_TABLE_NAME": documents_table.table_name,
@@ -221,7 +221,7 @@ class DocumentAPI(Construct):
             entry="./pace_backend/api/lambda/get_job_results_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[shared_status_lambda_layer],
             environment={
                 "DOCUMENTS_DYNAMO_DB_TABLE_NAME": documents_table.table_name,
@@ -252,7 +252,7 @@ class DocumentAPI(Construct):
             entry="./pace_backend/api/lambda/get_presigned_s3_url_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "REGION": Stack.of(self).region,
                 "DOCUMENTS_BUCKET_NAME": document_bucket.bucket_name,

--- a/blueprints/multipage-document-analysis/backend/pace_backend/text_analysis_workflow/__init__.py
+++ b/blueprints/multipage-document-analysis/backend/pace_backend/text_analysis_workflow/__init__.py
@@ -65,7 +65,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             self,
             "DocInfoLayer",
             entry=os.path.join(os.path.dirname(__file__), "shared"),
-            compatible_runtimes=[lambda_.Runtime.PYTHON_3_12],
+            compatible_runtimes=[lambda_.Runtime.PYTHON_3_13],
         )
 
 
@@ -76,7 +76,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             entry="./pace_backend/text_analysis_workflow/chunk_textract_document_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[shared_status_lambda_layer],
             environment={
                 "POWERTOOLS_LOG_LEVEL": "DEBUG",
@@ -120,7 +120,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             entry="./pace_backend/text_analysis_workflow/extract_data_to_schema_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[self.shared_doc_info_layer, shared_status_lambda_layer],
             environment={
                 "POWERTOOLS_LOG_LEVEL": "DEBUG",
@@ -169,7 +169,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             entry="./pace_backend/text_analysis_workflow/consolidate_report_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[self.shared_doc_info_layer, shared_status_lambda_layer],
             environment={
                 "POWERTOOLS_LOG_LEVEL": "DEBUG",
@@ -216,7 +216,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             entry="./pace_backend/text_analysis_workflow/persist_results_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[shared_status_lambda_layer],
             environment={
                 "POWERTOOLS_LOG_LEVEL": "DEBUG",
@@ -250,7 +250,7 @@ class DocAnalysisSFNPipeline(NestedStack):
             entry="./pace_backend/text_analysis_workflow/generate_pdf_fn",
             index="index.py",
             handler="lambda_handler",
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             layers=[self.shared_doc_info_layer, shared_status_lambda_layer],
             environment={
                 "POWERTOOLS_LOG_LEVEL": "DEBUG",


### PR DESCRIPTION
*Issue #, if available:*

Error raised by AWS CDK NAG regarding not using the latest Python version (3.13)

*Description of changes:*

Updated the CDK code to use Python 3.13 for the Lambda functions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
