### PR TITLE
Fix hardcoded connect instance ID

### DIFF
--- a/samples/connect-custom-bot/amazon_connect/flow_definition.json
+++ b/samples/connect-custom-bot/amazon_connect/flow_definition.json
@@ -399,7 +399,7 @@
     },
     {
       "Parameters": {
-        "QueueId": "arn:aws:connect:us-east-1:461004555540:instance/f5dbbb06-46e7-4435-beab-3b3303074765/queue/${QUEUE_ID}"
+        "QueueId": "arn:aws:connect:us-east-1:461004555540:instance/${INSTANCE_ID}/queue/${QUEUE_ID}"
       },
       "Identifier": "43fa1b05-de78-4874-aef3-588946d4ce74",
       "Type": "UpdateContactTargetQueue",

--- a/samples/connect-custom-bot/connect_custom_bot/connect_custom_bot_stack.py
+++ b/samples/connect-custom-bot/connect_custom_bot/connect_custom_bot_stack.py
@@ -128,6 +128,7 @@ class ConnectCustomBotStack(Stack):
                 body=flow_definition,
                 variables={
                     "QUEUE_ID": str(connect_queues.first_queue),
+                    "INSTANCE_ID": INSTANCE_ID,
                     "REPLACE_LAMBDA_FUNCTION": lambda_functions.start_bot.function_arn,
                 },
             )


### PR DESCRIPTION
*Issue #97*

*Description of changes:*
Updated the flow definition by parameterizing the QueueId with ${INSTANCE_ID}, and added the INSTANCE_ID variable to the CDK stack to ensure it is correctly passed during deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
