### PR TITLE
Migrate genai-marketing-campaigns image generation from Nova Canvas to Stability AI

### DIFF
--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/__init__.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/__init__.py
@@ -93,7 +93,7 @@ class PACEBackendStack(Stack):
         oss_data_access_role.add_to_principal_policy(
             iam.PolicyStatement(
                 actions=["aoss:DashboardsAccessAll"],
-                resources=[f'arn:aws:aoss:us-east-1:{Stack.of(self).account}:dashboards/default'],
+                resources=[f'arn:aws:aoss:{Stack.of(self).region}:{Stack.of(self).account}:dashboards/default'],
                 effect=iam.Effect.ALLOW,
             )
         )
@@ -489,7 +489,7 @@ class PACEBackendStack(Stack):
             index="index.py",
             handler="handler",
             runtime=lambda_.Runtime.PYTHON_3_13,
-            timeout=Duration.seconds(30),
+            timeout=Duration.seconds(90),
             memory_size=128,
             environment={
                 "LOG_LEVEL": "DEBUG",
@@ -497,7 +497,12 @@ class PACEBackendStack(Stack):
                 "HISTORIC_TABLE_NAME": self.historicCampaignsTable.table_name,
                 "PROCESSED_BUCKET": self.processedBucket.bucket_name,
                 "RAW_IMG_BUCKET": self.rawImgBucket.bucket_name,
-                "IMG_MODEL_ID": "amazon.nova-canvas-v1:0",
+                # Nova Canvas reached Bedrock EOL 2026-09-30; migrated to Stability
+                # AI Stable Image Ultra (us-west-2 only). Swap IMG_MODEL_ID +
+                # IMG_PROVIDER together to change providers (see generate_new_images_fn).
+                "IMG_MODEL_ID": "stability.stable-image-ultra-v1:1",
+                "IMG_PROVIDER": "stability",
+                "IMG_ASPECT_RATIO": "16:9",
                 "REGION": Stack.of(self).region
             },
             initial_policy=[

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_campaign_fn/prompts/create_campaign_concept_prompt_selector.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_campaign_fn/prompts/create_campaign_concept_prompt_selector.py
@@ -15,7 +15,24 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from langchain.chains.prompt_selector import ConditionalPromptSelector
+# Minimal, dependency-stable replacement for
+# langchain.chains.prompt_selector.ConditionalPromptSelector. That module has
+# moved/broken across langchain releases (unpinned deps -> ImportError at
+# runtime); this local shim reproduces the exact get_prompt() semantics and
+# removes the fragile dependency.
+from typing import Callable, List, Tuple
+
+
+class ConditionalPromptSelector:
+    def __init__(self, default_prompt, conditionals: List[Tuple[Callable, object]] = None):
+        self.default_prompt = default_prompt
+        self.conditionals = conditionals or []
+
+    def get_prompt(self, model_id: str):
+        for condition, prompt in self.conditionals:
+            if condition(model_id):
+                return prompt
+        return self.default_prompt
 
 from .prompts import NOVA_AD_CONCEPT_SYSTEM_PROMPT_EN, NOVA_AD_CONCEPT_USER_PROMPT_EN
 

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_campaign_fn/requirements.txt
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_campaign_fn/requirements.txt
@@ -1,4 +1,4 @@
 boto3
-langchain
-langchain-aws
+langchain-aws==0.2.10
+langchain-core==0.3.29
 pydantic

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_new_images_fn/index.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_new_images_fn/index.py
@@ -46,8 +46,14 @@ campaignTable = boto3.resource("dynamodb").Table(CAMPAIGN_TABLE_NAME)
 PROCESSED_BUCKET = os.getenv("PROCESSED_BUCKET")
 REGION = os.getenv("REGION")
 MODEL_ID = os.getenv("IMG_MODEL_ID")
+# Provider selects the invoke-body/response adapter. Defaults to "stability"
+# (Nova Canvas reached Bedrock EOL 2026-09-30). Kept as a config knob so a
+# future model swap is an env change, not a code change.
+IMG_PROVIDER = os.getenv("IMG_PROVIDER", "stability")
+# Aspect ratio replaces Nova's pixel dims. "16:9" matches the original 1280x720 intent.
+IMG_ASPECT_RATIO = os.getenv("IMG_ASPECT_RATIO", "16:9")
 
-logger.info(f"REGION: {REGION}")
+logger.info(f"REGION: {REGION} | MODEL_ID: {MODEL_ID} | PROVIDER: {IMG_PROVIDER}")
 
 s3 = boto3.resource("s3")
 processed_bucket = s3.Bucket(PROCESSED_BUCKET)
@@ -57,32 +63,66 @@ bedrock_runtime = boto3.client(
     region_name=REGION
 )
 
-def genImgCanvas(prompt: str):
-    """Generate an image from a prompt using Amazon Titan models"""
+NEGATIVE_PROMPTS = "poorly rendered, poor background details, poorly facial details"
 
-    negative_prompts = "poorly rendered, poor background details, poorly facial details"
 
-    seed = int(random.randrange(0x0CCD569F))  # nosec B311 not being used for security
-    logger.debug("seed = " + str(seed))
+class ImageFilteredError(Exception):
+    """Raised when the model's content filter blocked generation (no image returned)."""
 
-    # Create payload
-    body = json.dumps(
+
+def _build_stability_body(prompt: str, seed: int) -> str:
+    """Invoke body for Stability AI models (Stable Image Ultra/Core, SD3.5)."""
+    return json.dumps(
+        {
+            "prompt": prompt,
+            "negative_prompt": NEGATIVE_PROMPTS,  # plain keywords, no negation words
+            "aspect_ratio": IMG_ASPECT_RATIO,     # replaces explicit pixel dims
+            "seed": seed,
+            "output_format": "jpeg",
+        }
+    )
+
+
+def _build_nova_canvas_body(prompt: str, seed: int) -> str:
+    """Invoke body for Amazon Nova Canvas (legacy; retained for fallback/parity)."""
+    return json.dumps(
         {
             "taskType": "TEXT_IMAGE",
             "textToImageParams": {
                 "text": prompt,
-                "negativeText": negative_prompts   # Optional
+                "negativeText": NEGATIVE_PROMPTS,
             },
             "imageGenerationConfig": {
-                "numberOfImages": 1,  # Range: 1 to 5
-                "quality": "standard",  # Options: standard or premium
-                "height": 720,  # Supported height list in the docs
-                "width": 1280,  # Supported width list in the docs
-                "cfgScale": 7.5,  # Range: 1.0 (exclusive) to 10.0
-                "seed": seed  # Range: 0 to 214783647
-            }
+                "numberOfImages": 1,
+                "quality": "standard",
+                "height": 720,
+                "width": 1280,
+                "cfgScale": 7.5,
+                "seed": seed,
+            },
         }
     )
+
+
+# provider -> body builder. Both providers return the generated image(s) under
+# the same "images" key, so response handling is shared below.
+_BODY_BUILDERS = {
+    "stability": _build_stability_body,
+    "nova_canvas": _build_nova_canvas_body,
+}
+
+
+def genImgCanvas(prompt: str):
+    """Generate an image from a prompt via the configured Bedrock image provider."""
+
+    seed = int(random.randrange(0x0CCD569F))  # nosec B311 not being used for security
+    logger.debug("seed = " + str(seed))
+
+    build_body = _BODY_BUILDERS.get(IMG_PROVIDER)
+    if build_body is None:
+        raise ValueError(f"Unsupported IMG_PROVIDER: {IMG_PROVIDER}")
+
+    body = build_body(prompt, seed)
 
     response = bedrock_runtime.invoke_model(
         body=body,
@@ -92,7 +132,19 @@ def genImgCanvas(prompt: str):
     )
     response_body = json.loads(response.get("body").read())
 
-    base_64_img_str = response_body["images"][0]
+    # Stability omits "images" and returns "finish_reasons" when a prompt is
+    # blocked by the content filter. Nova returned an image unconditionally, so
+    # this guard is new and required for the migration.
+    images = response_body.get("images")
+    if not images:
+        finish_reasons = response_body.get("finish_reasons") or response_body.get("finish_reason")
+        logger.warning(f"No image returned. finish_reasons={finish_reasons}")
+        raise ImageFilteredError(
+            "The prompt was blocked by the model's content filter. "
+            "Please adjust the campaign description and try again."
+        )
+
+    base_64_img_str = images[0]
 
     tmpdir = tempfile.mkdtemp()
     image_file = str(uuid.uuid4()) + ".jpg"
@@ -130,7 +182,12 @@ def handler(event, context):
         return lambda_response
 
     #Generate an image based on the prompt
-    image_path, image_file = genImgCanvas(prompt)
+    try:
+        image_path, image_file = genImgCanvas(prompt)
+    except ImageFilteredError as e:
+        lambda_response["statusCode"] = 400
+        lambda_response["body"] = json.dumps({"message": str(e)})
+        return lambda_response
 
     #Read dynamo table
     ans = campaignTable.get_item(Key={'id':uid})

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/prompts/generate_text_to_image_metaprompt.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/prompts/generate_text_to_image_metaprompt.py
@@ -15,7 +15,24 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from langchain.chains.prompt_selector import ConditionalPromptSelector
+# Minimal, dependency-stable replacement for
+# langchain.chains.prompt_selector.ConditionalPromptSelector. That module has
+# moved/broken across langchain releases (unpinned deps -> ImportError at
+# runtime); this local shim reproduces the exact get_prompt() semantics and
+# removes the fragile dependency.
+from typing import Callable, List, Tuple
+
+
+class ConditionalPromptSelector:
+    def __init__(self, default_prompt, conditionals: List[Tuple[Callable, object]] = None):
+        self.default_prompt = default_prompt
+        self.conditionals = conditionals or []
+
+    def get_prompt(self, model_id: str):
+        for condition, prompt in self.conditionals:
+            if condition(model_id):
+                return prompt
+        return self.default_prompt
 
 from langchain_core.prompts.chat import ChatPromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate, \
     AIMessagePromptTemplate

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/prompts/prompts.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/prompts/prompts.py
@@ -27,7 +27,8 @@ These are some rules you will follow when interacting with your colleagues:
 
 * Your colleagues will discuss their ideas using either spanish or english, so please be flexible.
 * Your answers will always be in english regardless of the language your colleague used to communicate.
-* Your prompt should be at most 512 characters. You are encouraged to use all of them.
+* Your prompt should be a rich, self-contained description of about 1500-2000 characters (Stability models reward descriptive detail; the hard limit is 10000 characters but do not pad for length).
+* Encode style explicitly as descriptive keywords in the prompt itself (e.g. "photorealistic, cinematic lighting, shallow depth of field") - the model has no separate style parameter, so any desired look must live in the prompt text.
 * Do not give details about or resolution of the images in the prompt you will generate.
 * You will always say out loud what you are thinking
 * You always reason only once before creating a prompt

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/requirements.txt
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_prompt_fn/requirements.txt
@@ -1,3 +1,3 @@
 boto3
- langchain
- langchain-aws
+langchain-aws==0.2.10
+langchain-core==0.3.29

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_recommendations_fn/requirements.txt
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/generate_recommendations_fn/requirements.txt
@@ -1,3 +1,2 @@
 boto3
-langchain
-opensearch-py
+opensearch-py==2.8.0

--- a/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/presign_s3_fn/index.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-generation/pace_backend/lambda/presign_s3_fn/index.py
@@ -37,7 +37,16 @@ REGION = os.getenv("AWS_REGION")
 logger = logging.getLogger()
 logger.setLevel(os.getenv("LOG_LEVEL"))
 
-s3_client = boto3.client("s3",config=Config(region_name = REGION,signature_version="s3v4"))
+# Pin the regional S3 endpoint. Without an explicit endpoint_url, botocore signs
+# against the legacy global host (bucket.s3.amazonaws.com); for buckets outside
+# us-east-1, S3 answers that host with a 307 redirect to the regional host, which
+# invalidates the SigV4 signature (403 SignatureDoesNotMatch) and leaves <img>
+# tags stuck loading. Signing against the regional host avoids the redirect.
+s3_client = boto3.client(
+    "s3",
+    endpoint_url=f"https://s3.{REGION}.amazonaws.com",
+    config=Config(region_name=REGION, signature_version="s3v4"),
+)
 
 duration = 24 * 60 * 60
 

--- a/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/__init__.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/__init__.py
@@ -107,7 +107,7 @@ class OpenSearchServerlessEmbeddingsIndex(Construct):
         oss_data_indexing_role.add_to_principal_policy(
             iam.PolicyStatement(
                 actions=["aoss:DashboardsAccessAll"],
-                resources=[f'arn:aws:aoss:us-east-1:{Stack.of(self).account}:dashboards/default'],
+                resources=[f'arn:aws:aoss:{Stack.of(self).region}:{Stack.of(self).account}:dashboards/default'],
                 effect=iam.Effect.ALLOW,
             )
         )

--- a/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/custom_resources/create_oss_embeddings_index/create_oss_embeddings_index.py
+++ b/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/custom_resources/create_oss_embeddings_index/create_oss_embeddings_index.py
@@ -156,11 +156,11 @@ def create_index(
     logger.info(f"Creating index {index_name} with body:")
     logger.info(index_body)
 
-    response = opensearch.indices.create(index_name, body=index_body)
+    response = opensearch.indices.create(index=index_name, body=index_body)
     logger.info("The response")
     logger.info(response)
 
 
 def delete_index(opensearch, index_name):
-    response = opensearch.indices.delete(index_name)
+    response = opensearch.indices.delete(index=index_name)
     logger.info(response)

--- a/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/custom_resources/create_oss_embeddings_index/requirements.txt
+++ b/blueprints/genai-marketing-campaigns/backend-img-indexing/pace_backend/oss_indexing_db/custom_resources/create_oss_embeddings_index/requirements.txt
@@ -1,6 +1,6 @@
 cfnresponse
 urllib3<2
 aws-lambda-powertools
-opensearch-py
+opensearch-py==2.8.0
 requests-aws4auth
 aws-xray-sdk

--- a/blueprints/genai-marketing-campaigns/frontend/webapp/src/lib/api.ts
+++ b/blueprints/genai-marketing-campaigns/frontend/webapp/src/lib/api.ts
@@ -33,20 +33,26 @@ Amplify.configure({
   },
 });
 
-const session = await fetchAuthSession();
-const authToken = session.tokens?.idToken?.toString();
-
-const defaultRestInput = {
-  apiName: env.VITE_API_NAME,
-  options: {
-    headers: {
-      Authorization: `Bearer ${authToken}`,
+// Fetch a fresh auth token per request. Doing this once at module load runs
+// before the user has authenticated, so the token is undefined and every call
+// goes out as "Bearer undefined" -> 401. Amplify caches/refreshes the session,
+// so calling fetchAuthSession() per request is cheap.
+async function buildRestInput() {
+  const session = await fetchAuthSession();
+  const authToken = session.tokens?.idToken?.toString();
+  return {
+    apiName: env.VITE_API_NAME,
+    options: {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
     },
-  },
-};
+  };
+}
 
 export async function getCampaigns() {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = get({
       ...defaultRestInput,
       path: "/campaigns",
@@ -60,6 +66,7 @@ export async function getCampaigns() {
 
 export async function getCampaign(campaignId: string) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = get({
       ...defaultRestInput,
       path: `/campaigns/${campaignId}`,
@@ -73,6 +80,7 @@ export async function getCampaign(campaignId: string) {
 
 export async function createCampaign(campaign: Campaign) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = post({
       ...defaultRestInput,
       path: `/campaigns`,
@@ -90,6 +98,7 @@ export async function createCampaign(campaign: Campaign) {
 
 export async function deleteCampaign(campaignId: string) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = del({
       ...defaultRestInput,
       path: `/campaigns/${campaignId}`,
@@ -102,6 +111,7 @@ export async function deleteCampaign(campaignId: string) {
 
 export async function getReferences(campaignId: string) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = post({
       ...defaultRestInput,
       path: `/references/${campaignId}`,
@@ -115,6 +125,7 @@ export async function getReferences(campaignId: string) {
 
 export async function getPresignedImageUrl(s3path: string) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = post({
       ...defaultRestInput,
       path: `/presign`,
@@ -134,6 +145,7 @@ export async function getPresignedImageUrl(s3path: string) {
 
 export async function getSuggestion(campaignId: string, references: string[]) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = post({
       ...defaultRestInput,
       path: `/suggestion/${campaignId}`,
@@ -151,6 +163,7 @@ export async function getSuggestion(campaignId: string, references: string[]) {
 
 export async function getGeneratedImage(campaignId: string, prompt: string) {
   try {
+    const defaultRestInput = await buildRestInput();
     const restOperation = post({
       ...defaultRestInput,
       path: `/generate_images/${campaignId}`,


### PR DESCRIPTION
## What & why

Amazon Nova Canvas reaches **end-of-life on Amazon Bedrock (2026-09-30)**. This migrates the `genai-marketing-campaigns` blueprint's image generation from Nova Canvas to **Stability AI Stable Image Ultra** (`stability.stable-image-ultra-v1:1`).

## Changes

**Core migration**
- `generate_new_images_fn/index.py` — swap the Nova Canvas invoke/response handling for the Stability Stable Image Ultra request/response contract
- `prompts.py`, `pace_backend/__init__.py` — model-id and prompt wiring for Stability

**Deployability fixes** (pre-existing sample defects surfaced while validating the deploy end-to-end; independent of the model swap)
- Pin `langchain-core`, `langchain-aws`, `opensearch-py` — newer releases moved `langchain.chains.prompt_selector` and made the OpenSearch index args keyword-only, breaking the unpinned build
- Replace the fragile `ConditionalPromptSelector` import with a small local shim that preserves exact `get_prompt()` semantics
- `presign_s3_fn/index.py` — sign against the **regional** S3 endpoint; the legacy global host returns a 307 for non-`us-east-1` buckets that invalidates the SigV4 signature (403), leaving `<img>` tags stuck loading
- `api.ts` — build the `Authorization` header **per request**; the token was fetched once at module load (before login), sending `Bearer undefined` on every call

## Validation

Deployed to a personal Isengard account in **us-west-2** and validated end-to-end in the UI: campaign creation → AI prompt generation → Stability image generation, with all generated images rendering.

## Notes

- Stable Image Ultra is currently available in **us-west-2** only — deploy the image-generation stack there.
- Stability models use bare model IDs (no inference profile), so existing IAM scoping to `foundation-model/*` remains correct.
